### PR TITLE
fix(collector-jest): Resolve return type and value correctly

### DIFF
--- a/packages/collector-jest/src/extendedJestFn/extendedJestFn.spec.ts
+++ b/packages/collector-jest/src/extendedJestFn/extendedJestFn.spec.ts
@@ -5,7 +5,7 @@ let extendedJestFn;
 
 beforeEach(() => {
   jestFn = jest.fn;
-  extendedJestFn = extendedJestFnFactory(jestFn);
+  extendedJestFn = extendedJestFnFactory({ jestFn });
 });
 
 test('inject callPromise', () => {

--- a/packages/collector-jest/src/extendedJestFn/extendedJestFn.ts
+++ b/packages/collector-jest/src/extendedJestFn/extendedJestFn.ts
@@ -1,4 +1,4 @@
-const extendedJestFnFactory = jestFn => cb => {
+const extendedJestFnFactory = ({ jestFn }) => cb => {
   let extendedCb;
   const callPromise = new Promise(resolve => {
     extendedCb = (...args) => {

--- a/packages/collector-jest/src/registerProps/registerProps.ts
+++ b/packages/collector-jest/src/registerProps/registerProps.ts
@@ -67,7 +67,7 @@ function modifyValue(value: any): PropValue {
         modifiedValue.type,
         modifiedValue.value
       );
-    }
+    };
 
     const fnProp = createProp(PropType.FUNCTION, getCall());
 

--- a/packages/collector-jest/src/registerProps/registerProps.ts
+++ b/packages/collector-jest/src/registerProps/registerProps.ts
@@ -56,14 +56,18 @@ function modifyValue(value: any): PropValue {
       return createProp(PropType.UNKNOWN, {});
     }
 
-    const getCall = () =>
-      value.mock.calls[0]
-        ? createFunctionPropValue(
-            value.mock.calls[0],
-            value.mock.results[0].type,
-            value.mock.results[0].value
-          )
-        : {};
+    const getCall = () => {
+      const modifiedValue = modifyValue(value.mock.results[0].value);
+      if (!value.mock.calls[0]) {
+        return {};
+      }
+
+      return createFunctionPropValue(
+        value.mock.calls[0],
+        modifiedValue.type,
+        modifiedValue.value
+      );
+    }
 
     const fnProp = createProp(PropType.FUNCTION, getCall());
 


### PR DESCRIPTION
This PR fixes two bugs:
1. the DI for injecting jest fn into `extendedJestFn` was broken. It was used as a deconstructed object outside, but in the code it actually was a just the `jestFn` as the sole argument, Now the DI curry function uses object deconstruction
2. The values and types for function returns were not created correctly: It used the raw return value and type (which wrongly was `return` and not the actual value type) instead of the modified value (e.g. parse React elements to html string).