### PR TITLE
feat(collector-main): Add support for story decorators and typescript stories

### DIFF
--- a/packages/cli/src/commands/deploy.ts
+++ b/packages/cli/src/commands/deploy.ts
@@ -35,6 +35,7 @@ const deployAction = async ({
     collectors,
     steps,
     storyPath,
+    webpackConfig,
   });
   await uploadAction({ commit, steps });
 };

--- a/packages/cli/src/commands/runCollectors.ts
+++ b/packages/cli/src/commands/runCollectors.ts
@@ -22,6 +22,7 @@ export interface RunCollectorsCommandOptions extends BaseOptions {
   steps: any;
   executionPath: string;
   storyPath: string;
+  webpackConfig: string;
 }
 
 export const runCollectorsAction = async ({
@@ -29,8 +30,10 @@ export const runCollectorsAction = async ({
   executionPath,
   collectors: connectorConfig,
   storyPath,
+  webpackConfig,
 }: RunCollectorsCommandOptions) => {
   const collectors = connectorConfig.map(mapCollectorConfigToCollector);
+  const projectWebpackConfig = require(webpackConfig);
 
   const components: ComponentWithMetadata[] = getComponents();
 
@@ -47,6 +50,7 @@ export const runCollectorsAction = async ({
           components,
           executionPath,
           storyFiles,
+          projectWebpackConfig,
         });
       }),
     Promise.resolve()

--- a/packages/cli/src/utils/getWebpackConfig.ts
+++ b/packages/cli/src/utils/getWebpackConfig.ts
@@ -84,6 +84,10 @@ const getWebpackConfig = (
           NODE_ENV: JSON.stringify('production'),
         },
       }),
+      new webpack.NormalModuleReplacementPlugin(
+        /@storybook\/addons/,
+        pathUtils.join(executionPath, 'node_modules/@bojagi/collector-main/fakeStorybookAddons.js'),
+      ),
     ],
   };
 };

--- a/packages/cli/src/utils/getWebpackConfig.ts
+++ b/packages/cli/src/utils/getWebpackConfig.ts
@@ -86,7 +86,7 @@ const getWebpackConfig = (
       }),
       new webpack.NormalModuleReplacementPlugin(
         /@storybook\/addons/,
-        pathUtils.join(executionPath, 'node_modules/@bojagi/collector-main/fakeStorybookAddons.js'),
+        pathUtils.join(executionPath, 'node_modules/@bojagi/collector-main/fakeStorybookAddons.js')
       ),
     ],
   };

--- a/packages/collector-base/src/types.ts
+++ b/packages/collector-base/src/types.ts
@@ -11,6 +11,7 @@ export type CollectorFunctionOptions = {
   executionPath: string;
   components: ComponentWithMetadata[];
   storyFiles: string[];
+  projectWebpackConfig: webpack.Configuration;
 };
 
 export type CollectorFunction = (options: CollectorFunctionOptions) => Promise<void> | void;

--- a/packages/collector-main/fakeStorybookAddons.js
+++ b/packages/collector-main/fakeStorybookAddons.js
@@ -1,0 +1,1 @@
+module.exports.makeDecorator = () => (story) => story();

--- a/packages/collector-main/src/getWebpackConfig.ts
+++ b/packages/collector-main/src/getWebpackConfig.ts
@@ -1,19 +1,24 @@
+import * as webpack from 'webpack';
 import { getMocksPath, getOutputPath } from './pathFactories';
 
-export const getWebpackConfig = ({ executionPath, entry, webpack, componentPaths }) => ({
+export type GetWebpackConfigOptions = {
+  executionPath: string;
+  entry: string[];
+  webpack: typeof webpack;
+  componentPaths: string[];
+  projectWebpackConfig: webpack.Configuration;
+};
+
+export const getWebpackConfig = ({ executionPath, entry, webpack, componentPaths, projectWebpackConfig }) => ({
   entry,
   output: {
     path: getOutputPath(executionPath),
     filename: '[name].js',
     libraryTarget: 'umd',
   },
+  resolve: projectWebpackConfig.resolve,
   module: {
-    rules: [
-      {
-        test: /\.jsx?$/,
-        loader: 'babel-loader',
-      },
-    ],
+    rules: projectWebpackConfig.module.rules,
   },
   externals: {
     '@bojagi/collector-main': '@bojagi/collector-main',

--- a/packages/collector-main/src/index.ts
+++ b/packages/collector-main/src/index.ts
@@ -28,6 +28,7 @@ export const collector = async ({
   components,
   executionPath,
   storyFiles,
+  projectWebpackConfig,
 }: CollectorFunctionOptions) => {
   if (storyFiles.length === 0) {
     return;
@@ -47,7 +48,11 @@ export const collector = async ({
     entry,
     componentPaths,
     webpack,
+    projectWebpackConfig,
   });
+
+  console.log('config', config);
+  
 
   const compiler = webpack(config as any);
   await runCompiler(compiler);

--- a/packages/collector-main/src/index.ts
+++ b/packages/collector-main/src/index.ts
@@ -51,9 +51,6 @@ export const collector = async ({
     projectWebpackConfig,
   });
 
-  console.log('config', config);
-  
-
   const compiler = webpack(config as any);
   await runCompiler(compiler);
 


### PR DESCRIPTION
This adds:
* Support for story decorators (in default export object and for each story)
* Support for TypeScript (or any other language) stories