### PR TITLE
fix(cli): Use development environment for webpack function (for CRA css loading)

### DIFF
--- a/packages/cli/src/utils/getWebpackConfig.ts
+++ b/packages/cli/src/utils/getWebpackConfig.ts
@@ -18,7 +18,7 @@ export type GetWebpackConfigOutput = {
 
 async function buildProjectWebpackConfig(projectWebpackConfig) {
   return typeof projectWebpackConfig === 'function'
-    ? projectWebpackConfig({ env: 'production' }, {}) // TODO read from args etc
+    ? projectWebpackConfig('development') // TODO read from args etc
     : projectWebpackConfig;
 }
 


### PR DESCRIPTION
in CRA's production mode CSS is loaded as a separate file (`file-loader`, in development mode it's loaded as inline styles.
As we currently don't support `file-loader` assets, we need to use development mode to make CRA inline everything.