### PR TITLE
feat(cli): Memorize known dependency subtrees to speed up compiling

### DIFF
--- a/bin/integration.sh
+++ b/bin/integration.sh
@@ -21,19 +21,19 @@ function preparePackages {
 
 function integration {
   preparePackages
-  cd $PROJECT_ROOT && yarn jest --runInBand --config integration.jest.config.js --forceExit
+  cd $PROJECT_ROOT && yarn jest --runInBand --config integration.jest.config.js --forceExit ${@}
 }
 
 function integrationLocal {
   preparePackages
-  cd $PROJECT_ROOT && yarn jest --runInBand --config integration.local.jest.config.js --forceExit
+  cd $PROJECT_ROOT && yarn jest --runInBand --config integration.local.jest.config.js --forceExit ${@}
 }
 
 case $1 in
   integration )
-    integration
+    integration ${@:2}
     ;;
   integrationLocal )
-    integrationLocal
+    integrationLocal ${@:2}
     ;;
 esac

--- a/packages/cli/src/steps/compile/runWebpackCompiler.ts
+++ b/packages/cli/src/steps/compile/runWebpackCompiler.ts
@@ -110,9 +110,14 @@ function addDependencies({
 }) {
   return (module): Module => {
     const filePath = module.resource && getFilePath(module.resource);
+    const request = getRequest(module);
     if (memorizedDependencies.has(filePath)) {
       debug('reuse memorized dependency: %s', filePath);
-      return memorizedDependencies.get(filePath) as Module;
+      const memorizedModule = memorizedDependencies.get(filePath) as Module;
+      return {
+        ...memorizedModule,
+        request,
+      };
     }
 
     const isExternal = !!module.external;
@@ -131,7 +136,7 @@ function addDependencies({
       isExternal,
       isNodeModule,
       packageName,
-      request: getRequest(module),
+      request,
       isCircularImport,
       dependencies: !(isNodeModule || isExternal || isCircularImport)
         ? module.dependencies

--- a/packages/integration-tests/test/__snapshots__/bundle.integration.ts.snap
+++ b/packages/integration-tests/test/__snapshots__/bundle.integration.ts.snap
@@ -731,32 +731,7 @@ exports[`run bundle command 3`] = `
       \\"isExternal\\": false,
       \\"isNodeModule\\": false,
       \\"request\\": \\"./Ping\\",
-      \\"isCircularImport\\": false,
-      \\"dependencies\\": [
-       {
-        \\"isExternal\\": true,
-        \\"isNodeModule\\": false,
-        \\"packageName\\": \\"react\\",
-        \\"request\\": \\"react\\",
-        \\"isCircularImport\\": false
-       },
-       {
-        \\"filePath\\": \\"../../node_modules/styled-components/dist/styled-components.browser.esm.js\\",
-        \\"isExternal\\": false,
-        \\"isNodeModule\\": true,
-        \\"packageName\\": \\"styled-components\\",
-        \\"request\\": \\"styled-components\\",
-        \\"isCircularImport\\": false
-       },
-       {
-        \\"filePath\\": \\"src/components/Pong.js\\",
-        \\"gitPath\\": \\"packages/integration-tests/src/components/Pong.js\\",
-        \\"isExternal\\": false,
-        \\"isNodeModule\\": false,
-        \\"request\\": \\"./Pong\\",
-        \\"isCircularImport\\": true
-       }
-      ]
+      \\"isCircularImport\\": true
      }
     ]
    }


### PR DESCRIPTION
This PR adds an optimization that prevents complex and repeating dependency structures to run way quicker (and prevent them from getting stuck (happened in `@material-ui/core`).

It adds a memorization function to the dependency resolution, so if a subtree is already resolved, it doesn't need to resolve it again.