### PR TITLE
fix(cli): get git path for whole project instead for each file

### DIFF
--- a/packages/cli/src/steps/compile/__test__/compilationOutput.ts
+++ b/packages/cli/src/steps/compile/__test__/compilationOutput.ts
@@ -149,8 +149,8 @@ export function webpackCompilationOutput() {
 
 export function compilationDependencies() {
   return {
-    'gitpath/bojagi/A.js': {
-      id: `gitpath/bojagi/A.js`,
+    'bojagi/A.js': {
+      id: `bojagi/A.js`,
       filePath: `bojagi/A.js`,
       gitPath: 'bojagi/A.js',
       isExternal: false,
@@ -163,7 +163,7 @@ export function compilationDependencies() {
         { dependency: 'foreignNodeModules', request: 'foreignNodeModules' },
         { dependency: '@material-ui/icons', request: '@material-ui/icons/MyIcon' },
         { dependency: 'styled-components', request: 'styled-components' },
-        { dependency: 'gitpath/src/components/test.js', request: './test.js' },
+        { dependency: 'src/components/test.js', request: './test.js' },
       ],
     },
     react: {
@@ -195,38 +195,33 @@ export function compilationDependencies() {
       packageName: 'styled-components',
       dependencies: [],
     },
-    'gitpath/src/components/test.js': {
-      id: `gitpath/src/components/test.js`,
+    'src/components/test.js': {
+      id: `src/components/test.js`,
       isExternal: false,
       isNodeModule: false,
       filePath: `src/components/test.js`,
       gitPath: `src/components/test.js`,
       dependencies: [
-        { dependency: 'gitpath/src/components/XXX.js', request: '../XXX.js' },
-        { dependency: `gitpath/src/components/otherTest.js`, request: './otherTest.js' },
+        { dependency: 'src/components/XXX.js', request: '../XXX.js' },
+        { dependency: `src/components/otherTest.js`, request: './otherTest.js' },
       ],
     },
-    'gitpath/src/components/XXX.js': {
-      id: 'gitpath/src/components/XXX.js',
+    'src/components/XXX.js': {
+      id: 'src/components/XXX.js',
       filePath: 'src/components/XXX.js',
       gitPath: 'src/components/XXX.js',
       isExternal: false,
       isNodeModule: false,
       packageName: undefined,
-      dependencies: [{ dependency: 'gitpath/src/components/test.js', request: './test.js' }],
+      dependencies: [{ dependency: 'src/components/test.js', request: './test.js' }],
     },
-    'gitpath/src/components/otherTest.js': {
-      id: `gitpath/src/components/otherTest.js`,
+    'src/components/otherTest.js': {
+      id: `src/components/otherTest.js`,
       isExternal: false,
       isNodeModule: false,
       filePath: `src/components/otherTest.js`,
-<<<<<<< Updated upstream
-      gitPath: `gitpath/src/components/otherTest.js`,
-      dependencies: [{ dependency: 'gitpath/src/components/XXX.js', request: '../XXX.js' }],
-=======
       gitPath: `src/components/otherTest.js`,
       dependencies: [{ dependency: 'src/components/XXX.js', request: '../XXX.js' }],
->>>>>>> Stashed changes
     },
   };
 }

--- a/packages/cli/src/steps/compile/__test__/compilationOutput.ts
+++ b/packages/cli/src/steps/compile/__test__/compilationOutput.ts
@@ -152,7 +152,7 @@ export function compilationDependencies() {
     'gitpath/bojagi/A.js': {
       id: `gitpath/bojagi/A.js`,
       filePath: `bojagi/A.js`,
-      gitPath: 'gitpath/bojagi/A.js',
+      gitPath: 'bojagi/A.js',
       isExternal: false,
       isNodeModule: false,
       dependencies: [
@@ -200,7 +200,7 @@ export function compilationDependencies() {
       isExternal: false,
       isNodeModule: false,
       filePath: `src/components/test.js`,
-      gitPath: `gitpath/src/components/test.js`,
+      gitPath: `src/components/test.js`,
       dependencies: [
         { dependency: 'gitpath/src/components/XXX.js', request: '../XXX.js' },
         { dependency: `gitpath/src/components/otherTest.js`, request: './otherTest.js' },
@@ -209,7 +209,7 @@ export function compilationDependencies() {
     'gitpath/src/components/XXX.js': {
       id: 'gitpath/src/components/XXX.js',
       filePath: 'src/components/XXX.js',
-      gitPath: 'gitpath/src/components/XXX.js',
+      gitPath: 'src/components/XXX.js',
       isExternal: false,
       isNodeModule: false,
       packageName: undefined,
@@ -220,8 +220,13 @@ export function compilationDependencies() {
       isExternal: false,
       isNodeModule: false,
       filePath: `src/components/otherTest.js`,
+<<<<<<< Updated upstream
       gitPath: `gitpath/src/components/otherTest.js`,
       dependencies: [{ dependency: 'gitpath/src/components/XXX.js', request: '../XXX.js' }],
+=======
+      gitPath: `src/components/otherTest.js`,
+      dependencies: [{ dependency: 'src/components/XXX.js', request: '../XXX.js' }],
+>>>>>>> Stashed changes
     },
   };
 }

--- a/packages/cli/src/steps/compile/dependencies.spec.ts
+++ b/packages/cli/src/steps/compile/dependencies.spec.ts
@@ -1,10 +1,7 @@
-import { getDependencies } from './dependencies';
+import { getDependencies, getDependenciesForFilePath } from './dependencies';
 import { compilationDependencies, webpackCompilationOutput } from './__test__/compilationOutput';
-import getGitPath from '../../utils/getGitPath';
 
-jest.mock('../../utils/getGitPath');
-
-(getGitPath as any).mockImplementation(resource => `gitpath/${resource}`);
+console.log('process.cwd()', process.cwd());
 
 describe.each([[4], [5]])('Webpack version %s', webpackMajorVersion => {
   describe('getDependencies', () => {
@@ -19,8 +16,43 @@ describe.each([[4], [5]])('Webpack version %s', webpackMajorVersion => {
           ],
           modules: webpackCompilationOutput().modules,
           webpackMajorVersion,
+          projectGitPath: `${process.cwd()}`,
         })
       ).toEqual(compilationDependencies());
     });
+  });
+});
+
+describe('getDependenciesForFilePath', () => {
+  let modules;
+
+  beforeEach(() => {
+    modules = [
+      {
+        filePath: 'unimportantFile',
+        dependencies: ['a', 'b'],
+      },
+      {
+        filePath: './prefixedFile',
+        dependencies: ['c', 'd'],
+      },
+      {
+        filePath: 'nonPrefixedFile',
+        dependencies: ['e', 'f'],
+      },
+    ];
+  });
+
+  test('find module with leading "./"', () => {
+    const result = getDependenciesForFilePath(modules, './prefixedFile');
+    expect(result).toEqual(['c', 'd']);
+  });
+  test('find module without leading "./"', () => {
+    const result = getDependenciesForFilePath(modules, './nonPrefixedFile');
+    expect(result).toEqual(['e', 'f']);
+  });
+  test('return empty array if module was not found', () => {
+    const result = getDependenciesForFilePath(modules, './otherFile');
+    expect(result).toEqual([]);
   });
 });

--- a/packages/cli/src/steps/compile/dependencies.spec.ts
+++ b/packages/cli/src/steps/compile/dependencies.spec.ts
@@ -1,8 +1,6 @@
 import { getDependencies, getDependenciesForFilePath } from './dependencies';
 import { compilationDependencies, webpackCompilationOutput } from './__test__/compilationOutput';
 
-console.log('process.cwd()', process.cwd());
-
 describe.each([[4], [5]])('Webpack version %s', webpackMajorVersion => {
   describe('getDependencies', () => {
     test('get a map of all dependencies used', () => {

--- a/packages/cli/src/steps/compile/dependencies.ts
+++ b/packages/cli/src/steps/compile/dependencies.ts
@@ -73,21 +73,14 @@ function getModuleAsDependency(module, projectGitPath: string) {
   }
 
   const filePath = getFilePath(module.resource);
-<<<<<<< Updated upstream
-  const gitPath = getGitPath(filePath);
-=======
   const fullFilePath = path.resolve(filePath);
->>>>>>> Stashed changes
+  const gitPath = projectGitPath ? path.relative(projectGitPath, fullFilePath) : filePath;
   return {
-    id: gitPath || filePath,
+    id: gitPath,
     isExternal: !!module.external,
     isNodeModule: false,
     filePath,
-<<<<<<< Updated upstream
     gitPath,
-=======
-    gitPath: projectGitPath ? path.relative(projectGitPath, fullFilePath) : filePath,
->>>>>>> Stashed changes
   };
 }
 

--- a/packages/cli/src/steps/compile/index.tsx
+++ b/packages/cli/src/steps/compile/index.tsx
@@ -1,12 +1,6 @@
 import MemoryFS from 'memory-fs';
 import * as path from 'path';
-import {
-  StoryFileWithMetadata,
-  FileContent,
-  OutputFileContent,
-  LocalDependency,
-  DependencyReference,
-} from '../../types';
+import { StoryFileWithMetadata, FileContent, OutputFileContent } from '../../types';
 import { StepRunnerStep, StepRunnerActionOptions, StepOutput } from '../../containers/StepRunner';
 import { runWebpackCompiler } from './runWebpackCompiler';
 import { ScanStepOutput } from '../scan';
@@ -14,6 +8,7 @@ import { writeBojagiFile } from '../../utils/writeFile';
 import { getWebpackConfig } from '../../utils/getWebpackConfig';
 import debuggers, { DebugNamespaces } from '../../debug';
 import { NonVerboseError } from '../../errors';
+import { getDependenciesForFilePath } from './dependencies';
 
 import webpack = require('webpack');
 
@@ -48,7 +43,7 @@ type DependencyStepOutputs = {
 async function action({
   config,
   stepOutputs: {
-    scan: { storyFiles },
+    scan: { storyFiles, projectGitPath },
   },
 }: StepRunnerActionOptions<DependencyStepOutputs>): Promise<CompileStepOutput> {
   const { namespace } = config;
@@ -72,6 +67,7 @@ async function action({
     entrypoints,
     dependencyPackages,
     webpackMajorVersion,
+    projectGitPath,
   });
 
   const filesWithMetadata = await Promise.all(
@@ -122,14 +118,6 @@ function getPackageJsonDependencies(executionPath: string) {
   } catch {
     throw new Error('Can not read dependencies in package.json');
   }
-}
-
-function getDependenciesForFilePath(
-  modules: LocalDependency[],
-  filePath: string
-): DependencyReference[] {
-  const module = modules.find(m => m.filePath === filePath);
-  return (module && module.dependencies) || [];
 }
 
 function checkLimit(kind: string, limit: number, arr: any[]) {

--- a/packages/cli/src/steps/compile/runWebpackCompiler.spec.ts
+++ b/packages/cli/src/steps/compile/runWebpackCompiler.spec.ts
@@ -68,7 +68,7 @@ describe.each([[4], [5]])('Webpack version %s', webpackMajorVersion => {
       dependencies: compilationDependencies(),
       modules: [
         {
-          id: `gitpath/bojagi/A.js`,
+          id: `bojagi/A.js`,
           filePath: `bojagi/A.js`,
           gitPath: 'bojagi/A.js',
           isExternal: false,
@@ -81,7 +81,7 @@ describe.each([[4], [5]])('Webpack version %s', webpackMajorVersion => {
             { dependency: 'foreignNodeModules', request: 'foreignNodeModules' },
             { dependency: '@material-ui/icons', request: '@material-ui/icons/MyIcon' },
             { dependency: 'styled-components', request: 'styled-components' },
-            { dependency: 'gitpath/src/components/test.js', request: './test.js' },
+            { dependency: 'src/components/test.js', request: './test.js' },
           ],
         },
       ],

--- a/packages/cli/src/steps/compile/runWebpackCompiler.spec.ts
+++ b/packages/cli/src/steps/compile/runWebpackCompiler.spec.ts
@@ -1,10 +1,5 @@
 import { runWebpackCompiler } from './runWebpackCompiler';
-import getGitPath from '../../utils/getGitPath';
 import { compilationDependencies, webpackCompilationOutput } from './__test__/compilationOutput';
-
-jest.mock('../../utils/getGitPath');
-
-(getGitPath as any).mockImplementation(resource => `gitpath/${resource}`);
 
 let compiler;
 let entrypoints;
@@ -55,6 +50,7 @@ describe.each([[4], [5]])('Webpack version %s', webpackMajorVersion => {
         'foreignNodeModules',
       ],
       webpackMajorVersion,
+      projectGitPath: cwd,
     });
     expect(componentsContent).toEqual({
       outputContent: {
@@ -74,7 +70,7 @@ describe.each([[4], [5]])('Webpack version %s', webpackMajorVersion => {
         {
           id: `gitpath/bojagi/A.js`,
           filePath: `bojagi/A.js`,
-          gitPath: 'gitpath/bojagi/A.js',
+          gitPath: 'bojagi/A.js',
           isExternal: false,
           isNodeModule: false,
           dependencies: [
@@ -100,6 +96,7 @@ describe.each([[4], [5]])('Webpack version %s', webpackMajorVersion => {
         entrypoints,
         dependencyPackages: ['react', '@material-ui/icons', 'styled-components'],
         webpackMajorVersion,
+        projectGitPath: cwd,
       })
     ).rejects.toThrow('some error text');
   });
@@ -116,6 +113,7 @@ describe.each([[4], [5]])('Webpack version %s', webpackMajorVersion => {
         entrypoints,
         dependencyPackages: ['react', '@material-ui/icons', 'styled-components'],
         webpackMajorVersion,
+        projectGitPath: cwd,
       })
     ).rejects.toThrow('some compilation error text');
   });

--- a/packages/cli/src/steps/compile/runWebpackCompiler.ts
+++ b/packages/cli/src/steps/compile/runWebpackCompiler.ts
@@ -10,6 +10,7 @@ export type RunWebpackCompilerOutput = {
   outputContent: Record<string, string>;
   modules: LocalDependency[];
   assets: Record<string, string[]>;
+  projectGitPath?: string;
 };
 
 export const runWebpackCompiler = ({
@@ -17,6 +18,7 @@ export const runWebpackCompiler = ({
   entrypoints,
   dependencyPackages,
   webpackMajorVersion,
+  projectGitPath,
 }): Promise<RunWebpackCompilerOutput> =>
   new Promise((resolve, reject) => {
     compiler.run((err, output) => {
@@ -58,9 +60,12 @@ export const runWebpackCompiler = ({
           dependencyPackages,
           webpackMajorVersion,
           modules: componentModules,
+          projectGitPath,
         });
 
-        const modules = componentModules.map(m => findModuleInDependencies(m, dependencies));
+        const modules = componentModules.map(m =>
+          findModuleInDependencies(m, dependencies, projectGitPath)
+        );
 
         resolve({
           dependencies,

--- a/packages/cli/src/steps/scan/getExtendedStorybookFiles.ts
+++ b/packages/cli/src/steps/scan/getExtendedStorybookFiles.ts
@@ -1,9 +1,12 @@
 import * as path from 'path';
 import { StoryWithMetadata } from '../../types';
-import getGitPath from '../../utils/getGitPath';
 import { Config } from '../../config';
 
-const getEntrypointsFromFiles = (config: Config, files: string[]): StoryWithMetadata[] =>
+const getEntrypointsFromFiles = (
+  config: Config,
+  files: string[],
+  gitPathPrefix?: string
+): StoryWithMetadata[] =>
   files
     .map<StoryWithMetadata>(filePath => {
       // Regexp to find out file name
@@ -14,7 +17,8 @@ const getEntrypointsFromFiles = (config: Config, files: string[]): StoryWithMeta
         return undefined as any;
       }
 
-      const gitPath = getGitPath(filePath) as string;
+      const fullFilePath = path.resolve(filePath);
+      const gitPath = gitPathPrefix && path.relative(gitPathPrefix, fullFilePath);
       const absoluteFilePath = path.resolve(config.executionPath, filePath);
 
       const fileName = matchResult[1];


### PR DESCRIPTION
Before this fix the git path was received through the `git` command for every file. Each `gitPath` resolution needed ~25-30ms on my machine.
This PR changes the `gitPath` resolution to be only received at startup by the `git` command. Then this git project project path is used to resolve the git path for each file.

In addition this PR solves a bug that happenend on the material-ui repository:
Their webpack output for files were missing the `./` prefix. This caused the dependency arrays in the stories file to be empty.