### PR TITLE
fix(cli): Use production env for webpack configs

### DIFF
--- a/packages/cli/src/config/getProjectWebpackConfig.ts
+++ b/packages/cli/src/config/getProjectWebpackConfig.ts
@@ -76,6 +76,6 @@ async function loadConfigFromPath(webpackConfigPath) {
   const projectWebpackConfig = require(webpackConfigPath);
 
   return typeof projectWebpackConfig === 'function'
-    ? projectWebpackConfig('development') // TODO read from args etc
+    ? projectWebpackConfig('production') // TODO read from args etc
     : projectWebpackConfig;
 }


### PR DESCRIPTION
This makes CRA not complain about babel react reload