### PR TITLE
fix(cli): error.stack being empty string in error

### DIFF
--- a/packages/cli/src/components/ErrorMessage.tsx
+++ b/packages/cli/src/components/ErrorMessage.tsx
@@ -22,7 +22,7 @@ export function ErrorMessage({ error }: ErrorMessageProps) {
   return (
     <Box flexDirection="column">
       <Message emoji="x">Error: {error.message}</Message>
-      {error.stack && !(error as NonVerboseError).hideStackTrace && (
+      {!!error.stack && !(error as NonVerboseError).hideStackTrace && (
         <Box marginX={3} marginBottom={1}>
           <Text color="red">{error.stack}</Text>
         </Box>

--- a/packages/integration-test-utils/src/index.ts
+++ b/packages/integration-test-utils/src/index.ts
@@ -60,5 +60,6 @@ export function hash(aString) {
 export function execBojagi(basePath, cmd) {
   return execSync(`${getBojagiBin(basePath)} ${cmd}`, {
     cwd: basePath,
-  }).toString();
+    stdio: ['ignore', 'inherit', 'ignore'],
+  });
 }


### PR DESCRIPTION
in some rare cases (for example linting errors during compilation) err.stack would be an empty string and crash the cli as Ink expects string to be encapsulated in the Text component
