### PR TITLE
fix(cli): Support webpack cases where request is in module

### DIFF
--- a/packages/cli/src/steps/compile/__test__/compilationOutput.ts
+++ b/packages/cli/src/steps/compile/__test__/compilationOutput.ts
@@ -76,8 +76,8 @@ export function webpackCompilationOutput() {
           },
           // node module (no org)
           {
-            request: 'styled-components',
             module: {
+              request: 'styled-components',
               resource: `${cwd}/node_modules/styled-components/index.js`,
               dependencies: [],
             },

--- a/packages/cli/src/steps/compile/dependencies.ts
+++ b/packages/cli/src/steps/compile/dependencies.ts
@@ -94,7 +94,7 @@ function addSubDependencies(dep, subDependencies, projectGitPath: string): Depen
       !dep.isNodeModule && subDependencies
         ? subDependencies.map(({ request, module: subModule }) => {
             return {
-              request: getRequest(request) || getRequest(subModule.request),
+              request: getRequest(request || subModule.request),
               dependency: getModuleAsDependency(subModule, projectGitPath).id,
             };
           })

--- a/packages/cli/src/steps/compile/dependencies.ts
+++ b/packages/cli/src/steps/compile/dependencies.ts
@@ -94,7 +94,7 @@ function addSubDependencies(dep, subDependencies, projectGitPath: string): Depen
       !dep.isNodeModule && subDependencies
         ? subDependencies.map(({ request, module: subModule }) => {
             return {
-              request: getRequest(request),
+              request: getRequest(request) || getRequest(subModule.request),
               dependency: getModuleAsDependency(subModule, projectGitPath).id,
             };
           })
@@ -124,7 +124,10 @@ function ignoreDevDependencies(dependencyPackages) {
     // Module is part of project (no node_modules)
     !checkNodeModule(dep.module.resource) ||
     // Module is part of package.json "dependencies"
-    dependencyPackages.find(depName => dep.request.startsWith(depName));
+    dependencyPackages.find(depName => {
+      const request = dep.request || dep.module.request;
+      return request && request.startsWith(depName);
+    });
 }
 
 function getPackageName(module: any) {


### PR DESCRIPTION
I experienced a case where `request` was undefined in the `dependency` object but present at the `module` child object. With this change, this is respected.